### PR TITLE
Fix shell script for switching status of synchronize-panes and mouse mode

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -103,13 +103,13 @@ bind    S       run-shell "\
 # Toggle synchronize-panes
 bind    s       run-shell "\
     tmux show -w | grep -q synchronize-panes.*on && new_state=off || new_state=on; \
-    tmux setw synchronize-panes \$new_state >& /dev/null; \
+    tmux setw synchronize-panes \$new_state >/dev/null 2>&1; \
     tmux display \"synchronize-panes -> \$new_state\""
 
 # Toggle mouse mode
 bind    m       run-shell "\
     tmux show -g | grep -q 'mouse on' && new_state=off || new_state=on; \
-    tmux set -g mouse \$new_state >& /dev/null; \
+    tmux set -g mouse \$new_state >/dev/null 2>&1; \
     tmux display \"mouse-> \$new_state\""
 
 # vim:set ft=conf:


### PR DESCRIPTION
By using tmux.conf in current master branch, when I tried to switch status of synchronize-panes or mouse mode, I got an error report mentioned in next paragraph and the status wasn't changed.

```
'    tmux show -w | grep -q synchronize-panes.*on && new_state=off || new_state=on;     tmux setw synchronize-panes $new_state >& /dev/null;     tmux display "synchronize-panes -> $new_state"' returned 2
```

So I found out what caused that issue in tmux.conf and did this fixing.